### PR TITLE
Use Elixir formatter on codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@
 # If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
 
+# Ignore VS Code elixirls dialyzer output
+/.elixir_ls/
+
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez

--- a/lib/ex_aws/rds.ex
+++ b/lib/ex_aws/rds.ex
@@ -8,13 +8,33 @@ defmodule ExAws.RDS do
   @version "2014-10-31"
 
   @type db_instance_classes :: [
-    :db_t1_micro   | :db_m1_small    | :db_m1_medium  | :db_m1_large  | :db_m1_xlarge  |
-    :db_m2_xlarge  | :db_m2_2xlarge  | :db_m2_4xlarge | :db_m3_medium | :db_m3_large   |
-    :db_m3_xlarge  | :db_m3_2xlarge  | :db_m4_large   | :db_m4_xlarge | :db_m4_2xlarge |
-    :db_m4_4xlarge | :db_m4_10xlarge | :db_r3_large   | :db_r3_xlarge | :db_r3_2xlarge |
-    :db_r3_4xlarge | :db_r3_8xlarge  | :db_t2_micro   | :db_t2_small  | :db_t2_medium  |
-    :db_t2_large
-  ]
+          :db_t1_micro
+          | :db_m1_small
+          | :db_m1_medium
+          | :db_m1_large
+          | :db_m1_xlarge
+          | :db_m2_xlarge
+          | :db_m2_2xlarge
+          | :db_m2_4xlarge
+          | :db_m3_medium
+          | :db_m3_large
+          | :db_m3_xlarge
+          | :db_m3_2xlarge
+          | :db_m4_large
+          | :db_m4_xlarge
+          | :db_m4_2xlarge
+          | :db_m4_4xlarge
+          | :db_m4_10xlarge
+          | :db_r3_large
+          | :db_r3_xlarge
+          | :db_r3_2xlarge
+          | :db_r3_4xlarge
+          | :db_r3_8xlarge
+          | :db_t2_micro
+          | :db_t2_small
+          | :db_t2_medium
+          | :db_t2_large
+        ]
 
   @type filter :: {name :: binary, values :: [binary]}
 
@@ -22,13 +42,14 @@ defmodule ExAws.RDS do
   @doc """
   Adds a source identifier to an existing RDS event notification subscription.
   """
-  @spec add_source_id_to_subscription(source_id :: binary, subscription :: binary) :: ExAws.Operation.RestQuery.t
+  @spec add_source_id_to_subscription(source_id :: binary, subscription :: binary) ::
+          ExAws.Operation.RestQuery.t()
   def add_source_id_to_subscription(source_id, subscription) do
     query_params = %{
-      "Action"           => "AddSourceIdentifierToSubscription",
+      "Action" => "AddSourceIdentifierToSubscription",
       "SourceIdentifier" => source_id,
       "SubscriptionName" => subscription,
-      "Version"          => @version
+      "Version" => @version
     }
 
     request(:post, "/", query_params)
@@ -58,7 +79,11 @@ defmodule ExAws.RDS do
   @doc """
   Applies a pending maintenance action to a resource.
   """
-  @spec apply_pending_maintenance(resource_id :: binary, action :: apply_pending_maintenance_actions, opt_in_type :: apply_pending_maintenance_opt_in_types) :: ExAws.Operation.RestQuery.t
+  @spec apply_pending_maintenance(
+          resource_id :: binary,
+          action :: apply_pending_maintenance_actions,
+          opt_in_type :: apply_pending_maintenance_opt_in_types
+        ) :: ExAws.Operation.RestQuery.t()
   def apply_pending_maintenance(resource_id, action, opt_in_type) do
     query_params = %{
       "Action" => "ApplyPendingMaintenanceAction",
@@ -72,23 +97,24 @@ defmodule ExAws.RDS do
   end
 
   @type describe_db_instances_opts :: [
-    {:db_instance_identifier, binary}
-    | [{:filter_member_1, filter}, ...]
-    | {:marker, binary}
-    | {:max_records, 20..100}
-  ]
+          {:db_instance_identifier, binary}
+          | [{:filter_member_1, filter}, ...]
+          | {:marker, binary}
+          | {:max_records, 20..100}
+        ]
   @doc """
   Returns information about provisioned RDS instances.
   """
-  @spec describe_db_instances() :: ExAws.Operation.RestQuery.t
-  @spec describe_db_instances(opts :: describe_db_instances_opts) :: ExAws.Operation.RestQuery.t
+  @spec describe_db_instances() :: ExAws.Operation.RestQuery.t()
+  @spec describe_db_instances(opts :: describe_db_instances_opts) :: ExAws.Operation.RestQuery.t()
   def describe_db_instances(opts \\ []) do
-    query_params = opts
-    |> normalize_opts
-    |> Map.merge(%{
-      "Action"  => "DescribeDBInstances",
-      "Version" => @version
-    })
+    query_params =
+      opts
+      |> normalize_opts()
+      |> Map.merge(%{
+        "Action" => "DescribeDBInstances",
+        "Version" => @version
+      })
 
     request(:get, "/", query_params)
   end
@@ -101,56 +127,79 @@ defmodule ExAws.RDS do
   @type amazon_aurora_port_rage :: 1150..65535
 
   @type create_db_instance_opts :: [
-    {:auto_minor_version_upgrade, boolean}
-    | {:availability_zone, binary}
-    | {:backup_retention_period, integer}
-    | {:character_set_name, binary}
-    | {:copy_tags_to_snapshot, boolean}
-    | {:db_cluster_identifier, binary}
-    | {:db_name, binary}
-    | {:db_parameter_group_name, binary}
-    | [{:db_security_groups_member_1, [binary]}, ...]
-    | {:db_subnet_group_name, binary}
-    | {:domain, binary}
-    | {:domain_iam_role_name, binary}
-    | {:engine_version, binary}
-    | {:iops, integer}
-    | {:kms_key_id, binary}
-    | {:license_model, :license_included | :bring_your_own_license | :general_public_license}
-    | {:monitoring_interval, 0 | 1 | 5 | 10 | 15 | 30 | 60}
-    | {:monitoring_role_arn, binary}
-    | {:multi_az, boolean}
-    | {:option_group_name, binary}
-    | {:port, mysql_port_range | maria_db_port_range | postgres_sql_port_range | oracle_port_range | sql_server_port_range | amazon_aurora_port_rage}
-    | {:preferred_backup_window, binary}
-    | {:preferred_maintenance_window, binary}
-    | {:promotion_tier, 0..15}
-    | {:publicly_accessible, boolean}
-    | {:storage_encrypted, boolean}
-    | {:storage_type, :standard | :gp2 | :io1}
-    | [{:tags_member_1, [tag]}, ...]
-    | {:tde_credential_arn, binary}
-    | {:tde_credential_password, binary}
-    | [{:vpc_security_group_ids_member_1, [binary]}, ...]
-  ]
+          {:auto_minor_version_upgrade, boolean}
+          | {:availability_zone, binary}
+          | {:backup_retention_period, integer}
+          | {:character_set_name, binary}
+          | {:copy_tags_to_snapshot, boolean}
+          | {:db_cluster_identifier, binary}
+          | {:db_name, binary}
+          | {:db_parameter_group_name, binary}
+          | [{:db_security_groups_member_1, [binary]}, ...]
+          | {:db_subnet_group_name, binary}
+          | {:domain, binary}
+          | {:domain_iam_role_name, binary}
+          | {:engine_version, binary}
+          | {:iops, integer}
+          | {:kms_key_id, binary}
+          | {:license_model,
+             :license_included | :bring_your_own_license | :general_public_license}
+          | {:monitoring_interval, 0 | 1 | 5 | 10 | 15 | 30 | 60}
+          | {:monitoring_role_arn, binary}
+          | {:multi_az, boolean}
+          | {:option_group_name, binary}
+          | {:port,
+             mysql_port_range
+             | maria_db_port_range
+             | postgres_sql_port_range
+             | oracle_port_range
+             | sql_server_port_range
+             | amazon_aurora_port_rage}
+          | {:preferred_backup_window, binary}
+          | {:preferred_maintenance_window, binary}
+          | {:promotion_tier, 0..15}
+          | {:publicly_accessible, boolean}
+          | {:storage_encrypted, boolean}
+          | {:storage_type, :standard | :gp2 | :io1}
+          | [{:tags_member_1, [tag]}, ...]
+          | {:tde_credential_arn, binary}
+          | {:tde_credential_password, binary}
+          | [{:vpc_security_group_ids_member_1, [binary]}, ...]
+        ]
   @doc """
   Creates a new DB instance.
   """
-  @spec create_db_instance(instance_id :: binary, username :: binary, password :: binary, storage :: integer, class :: binary, engine :: binary) :: ExAws.Operation.RestQuery.t
-  @spec create_db_instance(instance_id :: binary, username :: binary, password :: binary, storage :: integer, class :: binary, engine :: binary, opts :: create_db_instance_opts) :: ExAws.Operation.RestQuery.t
+  @spec create_db_instance(
+          instance_id :: binary,
+          username :: binary,
+          password :: binary,
+          storage :: integer,
+          class :: binary,
+          engine :: binary
+        ) :: ExAws.Operation.RestQuery.t()
+  @spec create_db_instance(
+          instance_id :: binary,
+          username :: binary,
+          password :: binary,
+          storage :: integer,
+          class :: binary,
+          engine :: binary,
+          opts :: create_db_instance_opts
+        ) :: ExAws.Operation.RestQuery.t()
   def create_db_instance(instance_id, username, password, storage, class, engine, opts \\ []) do
-    query_params = opts
-    |> normalize_opts
-    |> Map.merge(%{
-      "Action"               => "CreateDBInstance",
-      "MasterUsername"       => username,
-      "MasterUserPassword"   => password,
-      "AllocatedStorage"     => storage,
-      "DBInstanceIdentifier" => instance_id,
-      "DBInstanceClass"      => class,
-      "Engine"               => engine,
-      "Version"              => @version
-    })
+    query_params =
+      opts
+      |> normalize_opts
+      |> Map.merge(%{
+        "Action" => "CreateDBInstance",
+        "MasterUsername" => username,
+        "MasterUserPassword" => password,
+        "AllocatedStorage" => storage,
+        "DBInstanceIdentifier" => instance_id,
+        "DBInstanceClass" => class,
+        "Engine" => engine,
+        "Version" => @version
+      })
 
     request(:post, "/", query_params)
   end
@@ -161,117 +210,139 @@ defmodule ExAws.RDS do
   @type oracle_allowed_storage :: 10..6144
 
   @type modify_db_instance_opts :: [
-    {:allocated_storage, mysql_allowed_storage | maria_db_allowed_storage | postgres_sql_allowed_storage | oracle_allowed_storage}
-    | {:allow_major_version_upgrade, boolean}
-    | {:apply_immediately, boolean}
-    | {:auto_minor_version_upgrade, boolean}
-    | {:backup_retention_period, integer}
-    | {:ca_certificate_identifier, binary}
-    | {:copy_tags_to_snapshot, boolean}
-    | {:db_instance_class, db_instance_classes}
-    | {:db_parameter_group_name, binary}
-    | {:db_port_number, mysql_port_range | maria_db_port_range | postgres_sql_port_range | oracle_port_range | sql_server_port_range}
-    | [{:sb_security_groups_member_1, [binary]}, ...]
-    | {:domain, binary}
-    | {:domain_iam_role_name, binary}
-    | {:engine_version, binary}
-    | {:iops, integer}
-    | {:master_user_password, binary}
-    | {:monitoring_interval, 0 | 1 | 5 | 10 | 15 | 30 | 60}
-    | {:monitoring_role_arn, binary}
-    | {:multi_az, boolean}
-    | {:new_db_instance_identifier, binary}
-    | {:option_group_name, binary}
-    | {:preferred_backup_window, binary}
-    | {:preferred_maintenance_window, binary}
-    | {:promotion_tier, 0..15}
-    | {:publicly_accessible, boolean}
-    | {:storage_type, :standard | :gp2 | :io1}
-    | {:tde_credential_arn, binary}
-    | {:tde_credential_password, binary}
-    | [{:vpc_security_group_ids_member_1, [binary]}, ...]
-  ]
+          {:allocated_storage,
+           mysql_allowed_storage
+           | maria_db_allowed_storage
+           | postgres_sql_allowed_storage
+           | oracle_allowed_storage}
+          | {:allow_major_version_upgrade, boolean}
+          | {:apply_immediately, boolean}
+          | {:auto_minor_version_upgrade, boolean}
+          | {:backup_retention_period, integer}
+          | {:ca_certificate_identifier, binary}
+          | {:copy_tags_to_snapshot, boolean}
+          | {:db_instance_class, db_instance_classes}
+          | {:db_parameter_group_name, binary}
+          | {:db_port_number,
+             mysql_port_range
+             | maria_db_port_range
+             | postgres_sql_port_range
+             | oracle_port_range
+             | sql_server_port_range}
+          | [{:sb_security_groups_member_1, [binary]}, ...]
+          | {:domain, binary}
+          | {:domain_iam_role_name, binary}
+          | {:engine_version, binary}
+          | {:iops, integer}
+          | {:master_user_password, binary}
+          | {:monitoring_interval, 0 | 1 | 5 | 10 | 15 | 30 | 60}
+          | {:monitoring_role_arn, binary}
+          | {:multi_az, boolean}
+          | {:new_db_instance_identifier, binary}
+          | {:option_group_name, binary}
+          | {:preferred_backup_window, binary}
+          | {:preferred_maintenance_window, binary}
+          | {:promotion_tier, 0..15}
+          | {:publicly_accessible, boolean}
+          | {:storage_type, :standard | :gp2 | :io1}
+          | {:tde_credential_arn, binary}
+          | {:tde_credential_password, binary}
+          | [{:vpc_security_group_ids_member_1, [binary]}, ...]
+        ]
   @doc """
   Modify settings for a DB instance.
   """
-  @spec modify_db_instance(instance_id :: binary) :: ExAws.Operation.RestQuery.t
-  @spec modify_db_instance(instance_id :: binary, opts :: modify_db_instance_opts) :: ExAws.Operation.RestQuery.t
+  @spec modify_db_instance(instance_id :: binary) :: ExAws.Operation.RestQuery.t()
+  @spec modify_db_instance(instance_id :: binary, opts :: modify_db_instance_opts) ::
+          ExAws.Operation.RestQuery.t()
   def modify_db_instance(instance_id, opts \\ []) do
-    query_params = opts
-    |> normalize_opts
-    |> Map.merge(%{
-      "Action"               => "ModifyDBInstance",
-      "DBInstanceIdentifier" => instance_id,
-      "Version"              => @version
-    })
+    query_params =
+      opts
+      |> normalize_opts()
+      |> Map.merge(%{
+        "Action" => "ModifyDBInstance",
+        "DBInstanceIdentifier" => instance_id,
+        "Version" => @version
+      })
 
     request(:patch, "/", query_params)
   end
 
   @type delete_db_instance_opts :: [
-    {:final_db_snapshot_identifier, binary} |
-    {:skip_final_snapshot, boolean}
-  ]
+          {:final_db_snapshot_identifier, binary}
+          | {:skip_final_snapshot, boolean}
+        ]
   @doc """
   Deletes a DB instance.
   """
-  @spec delete_db_instance(instance_id :: binary) :: ExAws.Operation.RestQuery.t
-  @spec delete_db_instance(instance_id :: binary, opts :: delete_db_instance_opts) :: ExAws.Operation.RestQuery.t
+  @spec delete_db_instance(instance_id :: binary) :: ExAws.Operation.RestQuery.t()
+  @spec delete_db_instance(instance_id :: binary, opts :: delete_db_instance_opts) ::
+          ExAws.Operation.RestQuery.t()
   def delete_db_instance(instance_id, opts \\ []) do
-    query_params = opts
-    |> normalize_opts
-    |> Map.merge(%{
-      "Action"               => "DeleteDBInstance",
-      "DBInstanceIdentifier" => instance_id,
-      "Version"              => @version
-    })
+    query_params =
+      opts
+      |> normalize_opts()
+      |> Map.merge(%{
+        "Action" => "DeleteDBInstance",
+        "DBInstanceIdentifier" => instance_id,
+        "Version" => @version
+      })
 
     request(:delete, "/", query_params)
   end
 
   @type reboot_db_instance_opts :: [
-    {:force_failover, boolean}
-  ]
+          {:force_failover, boolean}
+        ]
   @doc """
   Reboots a DB instance.
   """
-  @spec reboot_db_instance(instance_id :: binary) :: ExAws.Operation.RestQuery.t
-  @spec reboot_db_instance(instance_id :: binary, opts :: reboot_db_instance_opts) :: ExAws.Operation.RestQuery.t
+  @spec reboot_db_instance(instance_id :: binary) :: ExAws.Operation.RestQuery.t()
+  @spec reboot_db_instance(instance_id :: binary, opts :: reboot_db_instance_opts) ::
+          ExAws.Operation.RestQuery.t()
   def reboot_db_instance(instance_id, opts \\ []) do
-    query_params = opts
-    |> normalize_opts
-    |> Map.merge(%{
-      "Action"               => "RebootDBInstance",
-      "DBInstanceIdentifier" => instance_id,
-      "Version"              => @version
-    })
+    query_params =
+      opts
+      |> normalize_opts()
+      |> Map.merge(%{
+        "Action" => "RebootDBInstance",
+        "DBInstanceIdentifier" => instance_id,
+        "Version" => @version
+      })
 
     request(:get, "/", query_params)
   end
 
   @type describe_events_opts :: [
-    {:duration, integer}
-    | {:end_time, binary}
-    | [{:event_categories_member_1, [binary]}, ...]
-    | [{:filter_member_1, filter}, ...]
-    | {:marker, binary}
-    | {:max_records, 20..100}
-    | {:source_identifier, binary}
-    | {:source_type, :db_instance | :db_parameter_group | :db_security_group | :db_snapshot | :db_cluster | :db_cluster_snapsot}
-    | {:start_time, binary}
-  ]
+          {:duration, integer}
+          | {:end_time, binary}
+          | [{:event_categories_member_1, [binary]}, ...]
+          | [{:filter_member_1, filter}, ...]
+          | {:marker, binary}
+          | {:max_records, 20..100}
+          | {:source_identifier, binary}
+          | {:source_type,
+             :db_instance
+             | :db_parameter_group
+             | :db_security_group
+             | :db_snapshot
+             | :db_cluster
+             | :db_cluster_snapsot}
+          | {:start_time, binary}
+        ]
   @doc """
   Returns events related to DB instances, DB security groups, DB snapshots,
   and DB parameter groups for the past 14 days.
   """
-  @spec describe_events() :: ExAws.Operation.RestQuery.t
-  @spec describe_events(opts :: describe_db_instances_opts) :: ExAws.Operation.RestQuery.t
+  @spec describe_events() :: ExAws.Operation.RestQuery.t()
+  @spec describe_events(opts :: describe_db_instances_opts) :: ExAws.Operation.RestQuery.t()
   def describe_events(opts \\ []) do
-    query_params = opts
-    |> normalize_opts
-    |> Map.merge(%{
-      "Action"  => "DescribeEvents",
-      "Version" => @version,
+    query_params =
+      opts
+      |> normalize_opts()
+      |> Map.merge(%{
+        "Action" => "DescribeEvents",
+        "Version" => @version
       })
 
     request(:get, "/", query_params)
@@ -309,14 +380,22 @@ defmodule ExAws.RDS do
   Generates an auth token used to connect to a db with IAM credentials.
   See <http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html>
   """
-  @spec generate_db_auth_token(hostname :: binary, username :: binary, port :: integer, config :: map) :: binary
+  @spec generate_db_auth_token(
+          hostname :: binary,
+          username :: binary,
+          port :: integer,
+          config :: map
+        ) :: binary
   def generate_db_auth_token(hostname, username, port \\ 3306, config \\ %{}) do
     config = ExAws.Config.new(:rds, config)
-    query_params = ["Action": "connect", "DBUser": username]
-    datetime = :calendar.universal_time
+    query_params = [Action: "connect", DBUser: username]
+    datetime = :calendar.universal_time()
     # The signing utilities expect an actual URL, whereas RDS rejects a protocol on the token
     url = "https://#{hostname}:#{port}/"
-    {:ok, token} = ExAws.Auth.presigned_url(:get, url, :"rds-db", datetime, config, 900, query_params, "")
+
+    {:ok, token} =
+      ExAws.Auth.presigned_url(:get, url, :"rds-db", datetime, config, 900, query_params, "")
+
     String.trim_leading(token, "https://")
   end
 
@@ -332,6 +411,6 @@ defmodule ExAws.RDS do
   defp normalize_opts(opts) do
     opts
     |> Enum.into(%{})
-    |> camelize_keys
+    |> camelize_keys()
   end
 end

--- a/test/lib/rds_test.exs
+++ b/test/lib/rds_test.exs
@@ -16,261 +16,296 @@ defmodule ExAws.RDSTest do
   alias ExAws.RDS
 
   test "insert instance no options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"               => "CreateDBInstance",
-          "AllocatedStorage"     => 5,
-          "DBInstanceClass"      => "db.t1.micro",
-          "DBInstanceIdentifier" => "some-instance",
-          "Engine"               => "MySQL",
-          "MasterUserPassword"   => "mypassword",
-          "MasterUsername"       => "awsuser",
-          "Version"              => "2014-10-31"},
-        path: "/",
-        http_method: :post}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "CreateDBInstance",
+        "AllocatedStorage" => 5,
+        "DBInstanceClass" => "db.t1.micro",
+        "DBInstanceIdentifier" => "some-instance",
+        "Engine" => "MySQL",
+        "MasterUserPassword" => "mypassword",
+        "MasterUsername" => "awsuser",
+        "Version" => "2014-10-31"
+      },
+      path: "/",
+      http_method: :post
+    }
 
-    assert expected == RDS.create_db_instance "some-instance", "awsuser", "mypassword", 5, "db.t1.micro", "MySQL"
+    assert expected ==
+             RDS.create_db_instance(
+               "some-instance",
+               "awsuser",
+               "mypassword",
+               5,
+               "db.t1.micro",
+               "MySQL"
+             )
   end
 
   test "insert instance with options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"                  => "CreateDBInstance",
-          "AllocatedStorage"        => 5,
-          "DBInstanceClass"         => "db.t1.micro",
-          "DBInstanceIdentifier"    => "some-instance",
-          "Engine"                  => "MySQL",
-          "MasterUserPassword"      => "mypassword",
-          "MasterUsername"          => "awsuser",
-          "Version"                 => "2014-10-31",
-          "AutoMinorVersionUpgrade" => true,
-          "AvailabilityZone"        => "us-east-1e",
-          "MonitoringInterval"      => 10},
-        path: "/",
-        http_method: :post}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "CreateDBInstance",
+        "AllocatedStorage" => 5,
+        "DBInstanceClass" => "db.t1.micro",
+        "DBInstanceIdentifier" => "some-instance",
+        "Engine" => "MySQL",
+        "MasterUserPassword" => "mypassword",
+        "MasterUsername" => "awsuser",
+        "Version" => "2014-10-31",
+        "AutoMinorVersionUpgrade" => true,
+        "AvailabilityZone" => "us-east-1e",
+        "MonitoringInterval" => 10
+      },
+      path: "/",
+      http_method: :post
+    }
 
     assert expected ==
-      RDS.create_db_instance(
-        "some-instance",
-        "awsuser",
-        "mypassword",
-        5,
-        "db.t1.micro",
-        "MySQL",
-        [
-          auto_minor_version_upgrade: true,
-          availability_zone: "us-east-1e",
-          monitoring_interval: 10
-        ])
+             RDS.create_db_instance(
+               "some-instance",
+               "awsuser",
+               "mypassword",
+               5,
+               "db.t1.micro",
+               "MySQL",
+               auto_minor_version_upgrade: true,
+               availability_zone: "us-east-1e",
+               monitoring_interval: 10
+             )
   end
 
   test "describe_db_instances no options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"  => "DescribeDBInstances",
-          "Version" => "2014-10-31"},
-        path: "/",
-        http_method: :get}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{"Action" => "DescribeDBInstances", "Version" => "2014-10-31"},
+      path: "/",
+      http_method: :get
+    }
 
-    assert expected == RDS.describe_db_instances
+    assert expected == RDS.describe_db_instances()
   end
 
   test "describe_db_instances with options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"          => "DescribeDBInstances",
-          "Version"         => "2014-10-31",
-          "MaxRecords"      => 10,
-          "Filter.Member.1" => "some_filter"
-          },
-        path: "/",
-        http_method: :get}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "DescribeDBInstances",
+        "Version" => "2014-10-31",
+        "MaxRecords" => 10,
+        "Filter.Member.1" => "some_filter"
+      },
+      path: "/",
+      http_method: :get
+    }
 
-    assert expected == RDS.describe_db_instances([max_records: 10, "Filter.Member.1": "some_filter"])
+    assert expected ==
+             RDS.describe_db_instances(max_records: 10, "Filter.Member.1": "some_filter")
   end
 
   test "modify_db_instance no options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"               => "ModifyDBInstance",
-          "Version"              => "2014-10-31",
-          "DBInstanceIdentifier" => "some_instance"
-          },
-        path: "/",
-        http_method: :patch}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "ModifyDBInstance",
+        "Version" => "2014-10-31",
+        "DBInstanceIdentifier" => "some_instance"
+      },
+      path: "/",
+      http_method: :patch
+    }
 
     assert expected == RDS.modify_db_instance("some_instance")
   end
 
   test "modify_db_instance with options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"               => "ModifyDBInstance",
-          "Version"              => "2014-10-31",
-          "DBInstanceIdentifier" => "some_instance",
-          "AllocatedStorage"     => 20,
-          "DomainIamRoleName"    => "some_iam_name",
-          "Iops"                 => 20000,
-          "PubliclyAccessible"   => true
-          },
-        path: "/",
-        http_method: :patch}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "ModifyDBInstance",
+        "Version" => "2014-10-31",
+        "DBInstanceIdentifier" => "some_instance",
+        "AllocatedStorage" => 20,
+        "DomainIamRoleName" => "some_iam_name",
+        "Iops" => 20000,
+        "PubliclyAccessible" => true
+      },
+      path: "/",
+      http_method: :patch
+    }
 
     assert expected ==
-      RDS.modify_db_instance(
-        "some_instance",
-        [
-          allocated_storage: 20,
-          domain_iam_role_name: "some_iam_name",
-          iops: 20000,
-          publicly_accessible: true
-        ]
-      )
+             RDS.modify_db_instance(
+               "some_instance",
+               allocated_storage: 20,
+               domain_iam_role_name: "some_iam_name",
+               iops: 20000,
+               publicly_accessible: true
+             )
   end
 
   test "delete_db_instance no options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"               => "DeleteDBInstance",
-          "Version"              => "2014-10-31",
-          "DBInstanceIdentifier" => "some_instance"
-          },
-        path: "/",
-        http_method: :delete}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "DeleteDBInstance",
+        "Version" => "2014-10-31",
+        "DBInstanceIdentifier" => "some_instance"
+      },
+      path: "/",
+      http_method: :delete
+    }
 
-    assert expected == RDS.delete_db_instance "some_instance"
+    assert expected == RDS.delete_db_instance("some_instance")
   end
 
   test "delete_db_instance with options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"               => "DeleteDBInstance",
-          "Version"              => "2014-10-31",
-          "DBInstanceIdentifier" => "some_instance",
-          "SkipFinalSnapshot"    => true
-          },
-        path: "/",
-        http_method: :delete}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "DeleteDBInstance",
+        "Version" => "2014-10-31",
+        "DBInstanceIdentifier" => "some_instance",
+        "SkipFinalSnapshot" => true
+      },
+      path: "/",
+      http_method: :delete
+    }
 
-    assert expected == RDS.delete_db_instance "some_instance", [skip_final_snapshot: true]
+    assert expected == RDS.delete_db_instance("some_instance", skip_final_snapshot: true)
   end
 
   test "describe_events no options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"  => "DescribeEvents",
-          "Version" => "2014-10-31"
-          },
-        path: "/",
-        http_method: :get}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "DescribeEvents",
+        "Version" => "2014-10-31"
+      },
+      path: "/",
+      http_method: :get
+    }
 
-    assert expected == RDS.describe_events
+    assert expected == RDS.describe_events()
   end
 
   test "describe_events with options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"  => "DescribeEvents",
-          "Version" => "2014-10-31",
-          "Duration" => 50,
-          "EventCategories.member.1" => "some_event_category",
-          "SourceType" => "DbInstance"
-          },
-        path: "/",
-        http_method: :get}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "DescribeEvents",
+        "Version" => "2014-10-31",
+        "Duration" => 50,
+        "EventCategories.member.1" => "some_event_category",
+        "SourceType" => "DbInstance"
+      },
+      path: "/",
+      http_method: :get
+    }
 
-    assert expected == RDS.describe_events(
-      [
-        duration: 50,
-        "EventCategories.member.1": "some_event_category",
-        source_type: "DbInstance"
-      ]
-      )
+    assert expected ==
+             RDS.describe_events(
+               duration: 50,
+               "EventCategories.member.1": "some_event_category",
+               source_type: "DbInstance"
+             )
   end
 
   test "reboot_db_instance no options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"               => "RebootDBInstance",
-          "Version"              => "2014-10-31",
-          "DBInstanceIdentifier" => "some_instance",
-          },
-        path: "/",
-        http_method: :get}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "RebootDBInstance",
+        "Version" => "2014-10-31",
+        "DBInstanceIdentifier" => "some_instance"
+      },
+      path: "/",
+      http_method: :get
+    }
 
-    assert expected == RDS.reboot_db_instance "some_instance"
+    assert expected == RDS.reboot_db_instance("some_instance")
   end
 
   test "reboot_db_instance with options" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"               => "RebootDBInstance",
-          "Version"              => "2014-10-31",
-          "DBInstanceIdentifier" => "some_instance",
-          "ForceFailover"        => true
-          },
-        path: "/",
-        http_method: :get}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "RebootDBInstance",
+        "Version" => "2014-10-31",
+        "DBInstanceIdentifier" => "some_instance",
+        "ForceFailover" => true
+      },
+      path: "/",
+      http_method: :get
+    }
 
-    assert expected == RDS.reboot_db_instance "some_instance", [force_failover: true]
+    assert expected == RDS.reboot_db_instance("some_instance", force_failover: true)
   end
 
   test "apply_pending_maintenance" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"             => "ApplyPendingMaintenanceAction",
-          "Version"            => "2014-10-31",
-          "ResourceIdentifier" => "some_resource_id",
-          "ApplyAction"        => "some_action",
-          "OptInType"          => "some_type"
-          },
-        path: "/",
-        http_method: :post}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "ApplyPendingMaintenanceAction",
+        "Version" => "2014-10-31",
+        "ResourceIdentifier" => "some_resource_id",
+        "ApplyAction" => "some_action",
+        "OptInType" => "some_type"
+      },
+      path: "/",
+      http_method: :post
+    }
 
     assert expected ==
-      RDS.apply_pending_maintenance(
-        "some_resource_id",
-        "some_action",
-        "some_type"
-      )
+             RDS.apply_pending_maintenance(
+               "some_resource_id",
+               "some_action",
+               "some_type"
+             )
   end
 
   test "add_source_id_to_subscription" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"           => "AddSourceIdentifierToSubscription",
-          "Version"          => "2014-10-31",
-          "SourceIdentifier" => "some_source_id",
-          "SubscriptionName" => "some_subscription"
-          },
-        path: "/",
-        http_method: :post}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "AddSourceIdentifierToSubscription",
+        "Version" => "2014-10-31",
+        "SourceIdentifier" => "some_source_id",
+        "SubscriptionName" => "some_subscription"
+      },
+      path: "/",
+      http_method: :post
+    }
 
     assert expected == RDS.add_source_id_to_subscription("some_source_id", "some_subscription")
   end
 
   test "add_tags_to_resource" do
-    expected =
-      %ExAws.Operation.RestQuery{service: :rds, params: %{
-          "Action"              => "AddTagsToResource",
-          "Version"             => "2014-10-31",
-          "ResourceName"        => "some_resource",
-          "Tags.member.1.Key"   => "key1",
-          "Tags.member.1.Value" => "value1",
-          "Tags.member.2.Key"   => "key2",
-          "Tags.member.2.Value" => "value2"
-          },
-        path: "/",
-        http_method: :post}
+    expected = %ExAws.Operation.RestQuery{
+      service: :rds,
+      params: %{
+        "Action" => "AddTagsToResource",
+        "Version" => "2014-10-31",
+        "ResourceName" => "some_resource",
+        "Tags.member.1.Key" => "key1",
+        "Tags.member.1.Value" => "value1",
+        "Tags.member.2.Key" => "key2",
+        "Tags.member.2.Value" => "value2"
+      },
+      path: "/",
+      http_method: :post
+    }
 
     assert expected ==
-      RDS.add_tags_to_resource(
-        "some_resource",
-        [
-          {"key1", "value1"},
-          {"key2", "value2"}
-        ]
-      )
+             RDS.add_tags_to_resource(
+               "some_resource",
+               [
+                 {"key1", "value1"},
+                 {"key2", "value2"}
+               ]
+             )
   end
 
   test "list_tags_for_resource" do
@@ -290,5 +325,4 @@ defmodule ExAws.RDSTest do
 
     assert expected == RDS.list_tags_for_resource("arn:some-arn")
   end
-
 end


### PR DESCRIPTION
Having the code in the new standard format will make it easier for others
to contribute. A lot of developers have their editors configured to format
on save. If code is not formatted this will result in diffs that are difficult
to read.